### PR TITLE
Implemented MushroomHunterDao tests.

### DIFF
--- a/persistence/src/main/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoImpl.java
+++ b/persistence/src/main/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoImpl.java
@@ -2,8 +2,6 @@ package cz.muni.fi.pa165.mushrooms.dao;
 
 import cz.muni.fi.pa165.mushrooms.entity.MushroomHunter;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
@@ -13,7 +11,6 @@ import java.util.List;
 /**
  * @author Buvko
  */
-@Transactional(propagation = Propagation.REQUIRED)
 @Repository
 public class MushroomHunterDaoImpl implements MushroomHunterDao {
 

--- a/persistence/src/main/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoImpl.java
+++ b/persistence/src/main/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoImpl.java
@@ -2,6 +2,8 @@ package cz.muni.fi.pa165.mushrooms.dao;
 
 import cz.muni.fi.pa165.mushrooms.entity.MushroomHunter;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
@@ -11,7 +13,7 @@ import java.util.List;
 /**
  * @author Buvko
  */
-
+@Transactional(propagation = Propagation.REQUIRED)
 @Repository
 public class MushroomHunterDaoImpl implements MushroomHunterDao {
 
@@ -31,7 +33,7 @@ public class MushroomHunterDaoImpl implements MushroomHunterDao {
 
     @Override
     public void create(MushroomHunter c) {
-        if (c == null){
+        if (c == null) {
             throw new IllegalArgumentException("Null mushroom hunter at create.");
         }
         em.persist(c);
@@ -44,7 +46,7 @@ public class MushroomHunterDaoImpl implements MushroomHunterDao {
 
     @Override
     public void update(MushroomHunter c) {
-        if (c == null){
+        if (c == null) {
             throw new IllegalArgumentException("Null mushroom hunter at update.");
         }
         em.merge(c);
@@ -52,7 +54,7 @@ public class MushroomHunterDaoImpl implements MushroomHunterDao {
 
     @Override
     public List<MushroomHunter> findByFirstName(String firstName) {
-        if(firstName == null) {
+        if (firstName == null) {
             throw new IllegalArgumentException("firstName is null");
         }
 
@@ -68,7 +70,7 @@ public class MushroomHunterDaoImpl implements MushroomHunterDao {
 
     @Override
     public List<MushroomHunter> findBySurname(String surname) {
-        if(surname == null) {
+        if (surname == null) {
             throw new IllegalArgumentException("surname is null");
         }
         try {
@@ -83,13 +85,13 @@ public class MushroomHunterDaoImpl implements MushroomHunterDao {
 
     @Override
     public List<MushroomHunter> findByNickame(String userNickname) {
-        if(userNickname == null) {
+        if (userNickname == null) {
             throw new IllegalArgumentException("user nickname is null");
         }
         try {
             return em.createQuery("select c from MushroomHunter c where c.userNickname like :userNickname", MushroomHunter.class)
-                    .setParameter("userNickname", "%"+userNickname+"%").getResultList();
-        }catch (NoResultException e){
+                    .setParameter("userNickname", "%" + userNickname + "%").getResultList();
+        } catch (NoResultException e) {
             return null;
         }
     }

--- a/persistence/src/main/java/cz/muni/fi/pa165/mushrooms/entity/MushroomHunter.java
+++ b/persistence/src/main/java/cz/muni/fi/pa165/mushrooms/entity/MushroomHunter.java
@@ -1,6 +1,14 @@
 package cz.muni.fi.pa165.mushrooms.entity;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 import java.util.HashSet;
 import java.util.Objects;
@@ -14,25 +22,25 @@ import java.util.Set;
 public class MushroomHunter {
 
     @Id
-    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
-    @Column(nullable=false)
+    @Column(nullable = false)
     private String firstName;
 
     @NotNull
-    @Column(nullable=false)
+    @Column(nullable = false)
     private String surname;
 
     @OneToMany
-    @JoinColumn(name="hunter_visit", nullable=false)
+    @JoinColumn(name = "hunter_visit", nullable = false)
     Set<Visit> visits = new HashSet<>();
 
     private boolean isAdmin;
 
     @NotNull
-    @Column(nullable=false, unique = true)
+    @Column(nullable = false, unique = true)
     private String userNickname;
 
     @Column
@@ -96,10 +104,10 @@ public class MushroomHunter {
                 "id=" + id +
                 ", firstName='" + firstName + '\'' +
                 ", surname='" + surname + '\'' +
+                ", userNickname='" + userNickname + '\'' +
                 ", personalInfo='" + personalInfo + '\'' +
                 '}';
     }
-
 
     @Override
     public int hashCode() {

--- a/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTest.java
+++ b/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTest.java
@@ -5,6 +5,7 @@ import cz.muni.fi.pa165.mushrooms.validation.PersistenceSampleApplicationContext
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
@@ -14,9 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
 
 /**
+ * Tests for the MushroomHunterDao with prepopulated database.
+ *
  * @author bkompis
  */
 @ContextConfiguration(classes= PersistenceSampleApplicationContext.class)
@@ -58,26 +63,97 @@ public class MushroomHunterDaoTest extends AbstractJUnit4SpringContextTests {
         MushroomHunter hunter = mushroomHunterDao.findById(hunter1.getId());
         assertThat(hunter).isNotNull();
         assertThat(hunter).isEqualToComparingFieldByField(hunter1);
+        assertThat(hunter).isEqualTo(hunter1);
     }
 
     @Test
-    public void create() throws Exception {
+    public void findById_nullId() throws Exception {
+        assertThatThrownBy(() -> mushroomHunterDao.findById(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void delete() throws Exception {
+    public void findById_nonexistentId() throws Exception {
+        Long nonexistentId = hunter1.getId() + hunter2.getId();
+        assertThat(mushroomHunterDao.findById(nonexistentId)).isNull();
     }
 
     @Test
     public void findAll() throws Exception {
+        assertThat(mushroomHunterDao.findAll()).containsExactlyInAnyOrder(hunter1, hunter2);
     }
 
     @Test
-    public void findByFirstName() throws Exception {
+    public void findByFirstName_validName() throws Exception {
+        List<MushroomHunter> found = mushroomHunterDao.findByFirstName("John");
+        assertThat(found).containsExactly(hunter1);
     }
 
     @Test
-    public void findBySurname() throws Exception {
+    public void findByFirstName_unknownName() throws Exception {
+        List<MushroomHunter> found = mushroomHunterDao.findByFirstName("Nonexistent");
+        assertThat(found).isEmpty(); // or null?
+    }
+    @Test
+    public void findByFirstName_nullName() throws Exception {
+        assertThatThrownBy(() -> mushroomHunterDao.findByFirstName(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void findBySurname_validName() throws Exception {
+        List<MushroomHunter> found = mushroomHunterDao.findBySurname("Doe");
+        assertThat(found).containsExactly(hunter1);
+    }
+
+    @Test
+    public void findBySurname_unknownName() throws Exception {
+        List<MushroomHunter> found = mushroomHunterDao.findBySurname("Nonexistent");
+        assertThat(found).isEmpty(); // or null?
+    }
+
+    @Test
+    public void findBySurname_nullName() throws Exception {
+        assertThatThrownBy(() -> mushroomHunterDao.findBySurname(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void create_valid() throws Exception {
+        MushroomHunter newHunter = createMushroomHunter("Sylvanas", "Windrunner");
+        mushroomHunterDao.create(newHunter);
+        assertThat(newHunter.getId()).isNotNull();
+        assertThat(newHunter.getId()).isNotEqualTo(0); // necessary?
+
+        //compare the the newly created entity with the one stored in the database
+        assertThat(newHunter).isEqualToComparingFieldByField(mushroomHunterDao.findById(newHunter.getId()));
+    }
+
+
+    @Test
+    public void create_entityHasDuplicateId() throws Exception {
+        // todo: no setId() method
+    }
+
+    @Test
+    public void create_duplicateEntity() throws Exception{
+        //todo: needs proper unique constraints
+/*        try{
+            mushroomHunterDao.create(hunter1);
+        } catch (Exception e) {
+            System.err.println(e);
+        }*/
+        //assertThatThrownBy(() -> mushroomHunterDao.create(hunter1)).isInstanceOf(JpaSystemException.class);
+    }
+
+    @Test
+    public void create_entityAlreadySaved() throws Exception {
+        //TODO: need proper unique constraints
+        /*MushroomHunter newHunter = createMushroomHunter(hunter1.getFirstName(), hunter1.getSurname());
+        assertThatThrownBy(() -> mushroomHunterDao.create(newHunter)).isInstanceOf(JpaSystemException.class);*/
+    }
+//TODO: null names (create, update, delete)
+//TODO: tests for update
+
+    @Test
+    public void delete() throws Exception {
     }
 
 }

--- a/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTestNoSetup.java
+++ b/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTestNoSetup.java
@@ -1,13 +1,12 @@
 package cz.muni.fi.pa165.mushrooms.dao;
 
-import cz.muni.fi.pa165.mushrooms.entity.MushroomHunter;
 import cz.muni.fi.pa165.mushrooms.validation.PersistenceSampleApplicationContext;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,10 +15,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author bkompis
  */
-@ContextConfiguration(classes= PersistenceSampleApplicationContext.class)
+@ContextConfiguration(classes = PersistenceSampleApplicationContext.class)
 @TestExecutionListeners(TransactionalTestExecutionListener.class)
-@Transactional
-public class MushroomHunterDaoTestNoSetup {
+public class MushroomHunterDaoTestNoSetup extends AbstractJUnit4SpringContextTests {
     @Autowired
     private MushroomHunterDao mushroomHunterDao;
 
@@ -31,25 +29,21 @@ public class MushroomHunterDaoTestNoSetup {
 
     @Test
     public void findAll_emptyDatabase() throws Exception {
-        assertThat(mushroomHunterDao.findAll()).isEmpty(); //or null?
+        assertThat(mushroomHunterDao.findAll()).isEmpty();
     }
 
     @Test
     public void findByFirstName_emptyDatabase() throws Exception {
-        assertThat(mushroomHunterDao.findByFirstName("anything")).isEmpty(); // or null
+        assertThat(mushroomHunterDao.findByFirstName("anything")).isEmpty();
     }
 
     @Test
     public void findBySurname() throws Exception {
-        assertThat(mushroomHunterDao.findBySurname("anything")).isEmpty(); // or null
-
+        assertThat(mushroomHunterDao.findBySurname("anything")).isEmpty();
     }
 
     @Test
-    public void create_entityHasId() throws Exception {
-        MushroomHunter hunter = new MushroomHunter();
-        hunter.setFirstName("John");
-        hunter.setSurname("Doe");
-
+    public void findByNickname() throws Exception {
+        assertThat(mushroomHunterDao.findByNickame("anything")).isEmpty();
     }
 }

--- a/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTestNoSetup.java
+++ b/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTestNoSetup.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ContextConfiguration(classes = PersistenceSampleApplicationContext.class)
 @TestExecutionListeners(TransactionalTestExecutionListener.class)
-public class MushroomHunterDaoTestNoSetup extends AbstractJUnit4SpringContextTests {
+public class MushroomHunterDaoTestNoSetup extends AbstractTransactionalJUnit4SpringContextTests {
     @Autowired
     private MushroomHunterDao mushroomHunterDao;
 

--- a/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTestNoSetup.java
+++ b/persistence/src/test/java/cz/muni/fi/pa165/mushrooms/dao/MushroomHunterDaoTestNoSetup.java
@@ -1,0 +1,55 @@
+package cz.muni.fi.pa165.mushrooms.dao;
+
+import cz.muni.fi.pa165.mushrooms.entity.MushroomHunter;
+import cz.muni.fi.pa165.mushrooms.validation.PersistenceSampleApplicationContext;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the MushroomHunterDao with an empty database.
+ *
+ * @author bkompis
+ */
+@ContextConfiguration(classes= PersistenceSampleApplicationContext.class)
+@TestExecutionListeners(TransactionalTestExecutionListener.class)
+@Transactional
+public class MushroomHunterDaoTestNoSetup {
+    @Autowired
+    private MushroomHunterDao mushroomHunterDao;
+
+    @Test
+    public void findById_nonexistentId() throws Exception {
+        // the database contains no entries, and thus no ID's
+        assertThat(mushroomHunterDao.findById(1L)).isNull();
+    }
+
+    @Test
+    public void findAll_emptyDatabase() throws Exception {
+        assertThat(mushroomHunterDao.findAll()).isEmpty(); //or null?
+    }
+
+    @Test
+    public void findByFirstName_emptyDatabase() throws Exception {
+        assertThat(mushroomHunterDao.findByFirstName("anything")).isEmpty(); // or null
+    }
+
+    @Test
+    public void findBySurname() throws Exception {
+        assertThat(mushroomHunterDao.findBySurname("anything")).isEmpty(); // or null
+
+    }
+
+    @Test
+    public void create_entityHasId() throws Exception {
+        MushroomHunter hunter = new MushroomHunter();
+        hunter.setFirstName("John");
+        hunter.setSurname("Doe");
+
+    }
+}


### PR DESCRIPTION
* Still missing tests for cascading Visits, the proper relationship must first be implemented.
* Test cleanup needs some more research - currently, the whole AppllicationContext is recreated for each test method. This should be replaceable by proper transaction management - each method should run in a transaction and be rolled back after the execution finishes. -- **DONE in update 66abd8** --
* Test setup should maybe use @PersistenceContext instead of @PersistenceUnit - however, transactions didn't work properly when I tried that. -- **FIXED in update 66abd8** --
* @Transactional has been moved to the DAOImpl class for MushroomHunter from the test class. -- **REMOVED in update 66abd8** --
* MushroomHunter was formatted and had toString updated with userNickname.